### PR TITLE
update from upstream

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,6 @@ permissions:
   packages: write
 
 env:
-  CARGO_TERM_COLOR: always
   # set this to true in GitHub variables to enable building the container
   # HAS_CONTAINER: true
   # Use docker.io for Docker Hub if empty
@@ -109,13 +108,15 @@ jobs:
           rm ${HOME}/.cargo/bin/rustfmt
 
           rustup update
+          rustup show active-toolchain || rustup toolchain install
+          rustup show
 
           cargo --version
 
       - name: Get binstall
         shell: bash
+        working-directory: /tmp
         run: |
-          cd /tmp
           archive="cargo-binstall-x86_64-unknown-linux-musl.tgz"
           wget "https://github.com/cargo-bins/cargo-binstall/releases/latest/download/${archive}"
 
@@ -188,6 +189,8 @@ jobs:
           rm ${HOME}/.cargo/bin/rustfmt
 
           rustup update
+          rustup show active-toolchain || rustup toolchain install
+          rustup show
 
           cargo --version
 
@@ -234,8 +237,15 @@ jobs:
           rm ${HOME}/.cargo/bin/rustfmt
 
           rustup update
+          rustup show active-toolchain || rustup toolchain install
+          rustup show
 
           cargo --version
+
+      - name: Install rustfmt
+        shell: bash
+        run: |
+          rustup component add rustfmt
 
       - name: Check formatting
         shell: bash
@@ -275,6 +285,8 @@ jobs:
           rm ${HOME}/.cargo/bin/rustfmt
 
           rustup update
+          rustup show active-toolchain || rustup toolchain install
+          rustup show
 
           cargo --version
 
@@ -401,6 +413,8 @@ jobs:
           rm ${HOME}/.cargo/bin/rustfmt
 
           rustup update
+          rustup show active-toolchain || rustup toolchain install
+          rustup show
 
           cargo --version
 
@@ -450,6 +464,8 @@ jobs:
           rm ${HOME}/.cargo/bin/rustfmt
 
           rustup update
+          rustup show active-toolchain || rustup toolchain install
+          rustup show
 
           cargo --version
 
@@ -535,7 +551,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
         with:
-          name: containers-${{ env.APPLICATION_NAME }}
+          name: container-${{ env.APPLICATION_NAME }}
           path: /tmp/${{ env.UNIQUE_TAG }}.tar
           if-no-files-found: error
           retention-days: 1
@@ -545,22 +561,23 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - docker-build
+    env:
+      APPLICATION_NAME: PLACEHOLDER # overridden in step 'Set application name', this is merely to satisfy the linter
+      UNIQUE_TAG: PLACEHOLDER # same ^
     # Check if the event is not triggered by a fork
     if: |
       github.event.pull_request.head.repo.full_name == github.repository &&
       github.event_name == 'pull_request'
-    env:
-      APPLICATION_NAME: PLACEHOLDER # overridden in step 'Set application name', this is merely to satisfy the linter
     steps:
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
-
-      - name: Download artifact
-        uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
+      - name: Set up Docker
+        uses: docker/setup-docker-action@c2d73c1a11a9b44be6d855121d75c3e0dac814c1 # v4.2.0
         with:
-          path: /tmp/containers
-          pattern: containers-*
-          merge-multiple: true
+          daemon-config: |
+            {
+              "features": {
+                "containerd-snapshotter": true
+              }
+            }
 
       - name: Log into registry ${{ env.REGISTRY }}
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
@@ -569,35 +586,22 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Lowercase the image name
+        shell: bash
+        run: |
+          echo "IMAGE_NAME=${IMAGE_NAME,,}" >> ${GITHUB_ENV}
+
       - name: Set application name
         shell: bash
         run: |
           APPLICATION_NAME=${{ github.repository }}
           echo "APPLICATION_NAME=${APPLICATION_NAME##*/}" >> ${GITHUB_ENV}
 
-      - name: Lowercase the image name
+      - name: Set Docker tag (which is also the filename.tar)
         shell: bash
         run: |
-          echo "IMAGE_NAME=${IMAGE_NAME,,}" >> ${GITHUB_ENV}
-
-      - name: Ensure we have oras
-        uses: oras-project/setup-oras@5c0b487ce3fe0ce3ab0d034e63669e426e294e4d # v1.2.2
-
-      - name: Load images from artifacts
-        shell: bash
-        id: image
-        working-directory: /tmp/containers
-        run: |
-          echo "${{ secrets.GITHUB_TOKEN }}" | oras login -u "${{ github.actor }}" --password-stdin ${{ env.REGISTRY }}
-
-          ls -l /tmp/containers
-          for container in /tmp/containers/*
-          do
-            echo "Found ${container}"
-            tag=$(basename -- $container .tar)
-
-            oras copy --from-oci-layout "${container}:${tag}" "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${tag}"
-          done
+          UNIQUE_TAG=pr-${{ github.event.pull_request.base.sha }}-${{ github.event.pull_request.head.sha }}
+          echo "UNIQUE_TAG=${UNIQUE_TAG##*/}" >> ${GITHUB_ENV}
 
       - name: Extract Docker metadata
         uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
@@ -606,22 +610,42 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=ref,event=pr,suffix=-latest
-            type=raw,value=pr-${{ github.event.pull_request.base.sha }}-${{ github.event.pull_request.head.sha }}
+            type=raw,value=${{ env.UNIQUE_TAG }}
 
-      - name: Merge images
+      - name: Download artifact
+        uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
+        id: artifact
+        with:
+          path: /tmp/container/
+          name: container-${{ env.APPLICATION_NAME }}
+
+      - name: Load images from artifacts
         shell: bash
-        working-directory: /tmp/containers
         run: |
-          # all files in dir
-          containers=(*)
-          # yeet extension
-          containers=${containers[@]%.tar}
+          docker load --input ${{ steps.artifact.outputs.download-path }}/${{ env.UNIQUE_TAG }}.tar
+
+      - name: Push image to register
+        shell: bash
+        run: |
+          base_tag=$(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:%s ' ${{ env.UNIQUE_TAG }})
+
+          docker push ${base_tag}
+
+      - name: Set new tags on pushed image
+        shell: bash
+        working-directory: /tmp/container/
+        run: |
           new_tags="${{ join(steps.meta.outputs.tags, ' ') }}"
           new_tags=$(printf -- '--tag %s ' $new_tags)
-          expanded_containters_tags=$(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:%s ' ${containers})
-          docker buildx imagetools create $new_tags $expanded_containters_tags
+
+          base_tag=$(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:%s ' ${{ env.UNIQUE_TAG }})
+
+          docker buildx imagetools create $new_tags $base_tag
+
           for new_tag in $(echo "${{ join(steps.meta.outputs.tags, ' ') }}"); do
+            echo "${new_tag}:"
             docker buildx imagetools inspect --raw $new_tag
+            echo "" # newline
           done
 
   all-done:

--- a/.github/workflows/lint-commits.yml
+++ b/.github/workflows/lint-commits.yml
@@ -39,16 +39,20 @@ jobs:
       - name: Set up toolchain
         shell: bash
         run: |
-          rm ${HOME}/.cargo/bin/rustfmt
           rm ${HOME}/.cargo/bin/cargo-fmt
+          rm ${HOME}/.cargo/bin/rust-analyzer
+          rm ${HOME}/.cargo/bin/rustfmt
+
           rustup update
+          rustup show active-toolchain || rustup toolchain install
+          rustup show
 
           cargo --version
 
       - name: Get binstall
         shell: bash
+        working-directory: /tmp
         run: |
-          cd /tmp
           archive="cargo-binstall-x86_64-unknown-linux-musl.tgz"
           wget "https://github.com/cargo-bins/cargo-binstall/releases/latest/download/${archive}"
 

--- a/.github/workflows/publish-crate-after-release.yml
+++ b/.github/workflows/publish-crate-after-release.yml
@@ -66,6 +66,8 @@ jobs:
           rm ${HOME}/.cargo/bin/rustfmt
 
           rustup update
+          rustup show active-toolchain || rustup toolchain install
+          rustup show
 
           cargo --version
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,13 +60,15 @@ jobs:
           rm ${HOME}/.cargo/bin/rustfmt
 
           rustup update
+          rustup show active-toolchain || rustup toolchain install
+          rustup show
 
           cargo --version
 
       - name: Get binstall
         shell: bash
+        working-directory: /tmp
         run: |
-          cd /tmp
           archive="cargo-binstall-x86_64-unknown-linux-musl.tgz"
           wget "https://github.com/cargo-bins/cargo-binstall/releases/latest/download/${archive}"
 

--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -54,13 +54,15 @@ jobs:
           rm ${HOME}/.cargo/bin/rustfmt
 
           rustup update
+          rustup show active-toolchain || rustup toolchain install
+          rustup show
 
           cargo --version
 
       - name: Get binstall
         shell: bash
+        working-directory: /tmp
         run: |
-          cd /tmp
           archive="cargo-binstall-x86_64-unknown-linux-musl.tgz"
           wget "https://github.com/cargo-bins/cargo-binstall/releases/latest/download/${archive}"
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -294,9 +294,9 @@ checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itoa"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "lazy_static"
@@ -430,18 +430,18 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.93"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
+checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.38"
+version = "1.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
+checksum = "c1f1914ce909e1658d9907913b4b91947430c7d9be598b15a1912935b8c04801"
 dependencies = [
  "proc-macro2",
 ]
@@ -567,9 +567,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.98"
+version = "2.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36147f1a48ae0ec2b5b3bc5b537d267457555a10dc06f3dbc8cb11ba3006d3b1"
+checksum = "e02e925281e18ffd9d640e234264753c43edc62d64b2d4cf898f1bc5e75f3fc2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -733,9 +733,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00e2473a93778eb0bad35909dff6a10d28e63f792f16ed15e404fca9d5eeedbe"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "unicode-xid"


### PR DESCRIPTION
- **chore(deps): update actions/upload-artifact action to v4.6.1**
- **chore: remove oras**
- **chore: forgot `push`**
- **chore: push by tag, not filepath...**
- **chore: add logging, try remove unneeded (?) buildx**
- **chore(deps): pin docker/setup-docker-action action to 370a7da**
- **chore(deps): update docker/setup-docker-action action to v4.1.0**
- **chore(deps): update dependency prettier to v3.5.2**
- **chore(deps): lock file maintenance**
- **chore(deps): update rust:1.85.0 docker digest to 9285bed**
- **chore(deps): update actions/download-artifact action to v4.1.9**
- **chore(deps): update rust:1.85.0 docker digest to f495f32**
- **chore(deps): update rust:1.85.0 docker digest to caa4a0e**
- **chore(deps): update docker/metadata-action action to v5.7.0**
- **chore(deps): update docker/setup-buildx-action action to v3.10.0**
- **chore(deps): update docker/setup-docker-action action to v4.2.0**
- **chore(deps): update codecov/codecov-action action to v5.4.0**
- **chore(deps): update docker/build-push-action action to v6.15.0**
- **chore(deps): update returntocorp/semgrep docker tag to v1.110.0**
- **chore(deps): update actions/cache action to v4.2.2**
- **chore(deps): update dependency prettier to v3.5.3**
- **chore: fix for rustup 1.28.0 not installing needed toolchain by default**
- **chore: install rust-fmt**
- **chore: use working-directory**
