### PR TITLE
update from upstream

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule ".vscode/rust-prettifier-for-lldb"]
+	path = .vscode/rust-prettifier-for-lldb
+	url = https://github.com/cmrschwarz/rust-prettifier-for-lldb

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,6 @@
 .git
-.github/actions/
+.mypy_cache
+.vscode/rust-prettifier-for-lldb
 CHANGELOG.md
 profiling
 reports

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -32,8 +32,8 @@
                 "RUST_BACKTRACE": "1",
                 "RUST_LOG": "ERROR,mdns_reflector=ERROR"
             },
-            "internalConsoleOptions": "openOnSessionStart",
-            "terminal": "console"
+            "internalConsoleOptions": "neverOpen",
+            "terminal": "integrated"
         },
         {
             "type": "lldb",
@@ -56,8 +56,8 @@
                 "RUST_BACKTRACE": "1",
                 "RUST_LOG": "DEBUG,mdns_reflector=TRACE"
             },
-            "internalConsoleOptions": "openOnSessionStart",
-            "terminal": "console"
+            "internalConsoleOptions": "neverOpen",
+            "terminal": "integrated"
         },
         {
             "type": "lldb",
@@ -81,8 +81,8 @@
                 "RUST_BACKTRACE": "1",
                 "RUST_LOG": "DEBUG,mdns_reflector=TRACE"
             },
-            "internalConsoleOptions": "openOnSessionStart",
-            "terminal": "console"
+            "internalConsoleOptions": "neverOpen",
+            "terminal": "integrated"
         },
         {
             "type": "lldb",
@@ -106,8 +106,8 @@
                 "RUST_BACKTRACE": "1",
                 "RUST_LOG": "DEBUG,mdns_reflector=TRACE"
             },
-            "internalConsoleOptions": "openOnSessionStart",
-            "terminal": "console"
+            "internalConsoleOptions": "neverOpen",
+            "terminal": "integrated"
         }
     ]
 }

--- a/.vscode/rust_prettifier_for_lldb.py
+++ b/.vscode/rust_prettifier_for_lldb.py
@@ -1,0 +1,1 @@
+./rust-prettifier-for-lldb/rust_prettifier_for_lldb.py

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,13 +1,11 @@
 {
-    "debug.internalConsoleOptions": "openOnSessionStart",
+    "debug.internalConsoleOptions": "neverOpen",
+    "lldb.launch.terminal": "integrated",
+    "lldb.launch.expressions": "simple",
+    "lldb.launch.preRunCommands": [
+        "command script import ${workspaceFolder}/.vscode/rust_prettifier_for_lldb.py"
+    ],
     "prettier.configPath": "./.prettierrc.cjs",
-    "rust-analyzer.debug.engineSettings": {
-        "lldb": {
-            "internalConsoleOptions": "openOnSessionStart",
-            "terminal": "console"
-        }
-    },
-    "rust-analyzer.debug.openDebugPane": true,
     "rust-analyzer.runnables.extraEnv": {
         "RUST_LOG": "DEBUG,mdns_reflector=TRACE"
     },

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -567,9 +567,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.100"
+version = "2.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
+checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
 dependencies = [
  "proc-macro2",
  "quote",


### PR DESCRIPTION
- **chore(deps): lock file maintenance**
- **fix: start tracking lldb debug helper**
- **chore(deps): update returntocorp/semgrep docker tag to v1.120.0**
- **chore(deps): update github/codeql-action action to v3.28.16**
- **chore(deps): update node.js to v22.15.0**
- **chore(deps): update docker/build-push-action action to v6.16.0**
- **chore(deps): update actions/download-artifact action to v4.3.0**
- **chore: set default debug visualizer**
- **chore: update debug setup**
